### PR TITLE
[FEATURE] Mise en place de la CI (PIX-8429)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,29 +10,28 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - checkout:
-          context: Pix
+      - lint_and_test
 
 jobs:
-  checkout:
+  lint_and_test:
     docker:
       - image: cimg/node:18.16
       - image: postgres:14.6-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
-    resource_class: small
-    working_directory: ~/pix-audit-logger
     steps:
       - checkout
       - run:
-          name: Lint and test
+          name: Install dependencies
+          command: npm ci --no-optional
+      - run:
+          name: Lint
+          command: npm run lint
+      - run:
+          name: Test
+          command: npm run test
           environment:
             TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci
-          command: |
-            rm -rf .git/
-            npm ci
-            npm run lint
-            npm run test
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,30 @@
+# This config is equivalent to both the '.circleci/extended/orb-free.yml' and the base '.circleci/config.yml'
+version: 2.1
+
+# Orbs are reusable packages of CircleCI configuration that you may share across projects, enabling you to create encapsulated, parameterized commands, jobs, and executors that can be used across multiple projects.
+# See: https://circleci.com/docs/orb-intro/
+orbs:
+  node: circleci/node@4.7
+
+workflows:
+  version: 2
+  build-and-test:
+    jobs:
+      - checkout:
+          context: Pix
+
+jobs:
+  checkout:
+    docker:
+      - image: cimg/node:18.16
+    resource_class: small
+    working_directory: ~/pix-audit-logger
+    steps:
+      - checkout
+      - run:
+          name: Lint
+          command: |
+            rm -rf .git/
+            npm ci
+            npm run lint
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,14 +17,22 @@ jobs:
   checkout:
     docker:
       - image: cimg/node:18.16
+      - image: postgres:14.6-alpine
+        environment:
+          POSTGRES_USER: circleci
+          POSTGRES_HOST_AUTH_METHOD: trust
     resource_class: small
     working_directory: ~/pix-audit-logger
     steps:
       - checkout
       - run:
-          name: Lint
+          name: Lint and test
+          environment:
+            TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci
           command: |
             rm -rf .git/
             npm ci
             npm run lint
+            npm run test
+
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "local:trigger-lint-on-commit": "husky install",
     "local:prevent-trigger-lint-on-commit": "git config --unset core.hooksPath",
     "preinstall": "npx check-engine",
-    "test": "npm run lint"
+    "test": "NODE_ENV=test npm run db:prepare"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "local:trigger-lint-on-commit": "husky install",
     "local:prevent-trigger-lint-on-commit": "git config --unset core.hooksPath",
     "preinstall": "npx check-engine",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "npm run lint"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## :unicorn: Problème

Chaque nouvelle PR est susceptible d'apporter des risques de régression si la CI avec un minimum de vérifications n'est pas mise en place.

## :robot: Proposition

Configurer la CI et lancer `npm run lint` et `NODE_ENV=test npm run db:prepare`.

## :rainbow: Remarques

RAS

## :100: Pour tester

Aller sur https://app.circleci.com/ et vérifier que cette PR exécute `npm run lint` et `NODE_ENV=test npm run db:prepare`.
