### PR TITLE
[DOCS] Ajouter un avertissement sur l'obsolescence du dépôt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# ⚠️ **Dépôt obsolète** 
+Le code de Pix Audit Logger se trouve désormais dans [le dépôt principal 1024pix/pix](https://github.com/1024pix/pix/tree/dev/audit-logger).
+
 # Pix Audit Logger
 
 ## Installation


### PR DESCRIPTION
## :unicorn: Problème

Le code de pix-audit-logger a été déplacé dans le repository principal, mais rien n'indiquer cette décision dans l'ancien repository.

## :robot: Proposition

Ajouter un avertissement dans le README, puis archiver le repository.

## :rainbow: Remarques

*RAS*

## :100: Pour tester

Vérifier le bon affichage de l'avertissement dans le fichier README.